### PR TITLE
Fix the bug for 'java_lang_config'

### DIFF
--- a/client/PHP/languages.php
+++ b/client/PHP/languages.php
@@ -60,7 +60,8 @@ return [
         'run' => [
             'command' => '/usr/bin/java -cp {exe_dir} -Xss1M -XX:MaxPermSize=16M -XX:PermSize=8M -Xms16M -Xmx{max_memory}k -Djava.security.manager -Djava.security.policy==/etc/java_policy -Djava.awt.headless=true Main',
             'seccomp_rule' => null,
-            'env' => array_merge(['MALLOC_ARENA_MAX=1'], $default_env)
+            'env' => $default_env,
+            'memory_limit_check_only' => 1
         ]
     ],
     'py2_lang_config' => [


### PR DESCRIPTION
提交JAVA代码时，json返回结果一直显示运行时错误，原因是在java的配置中，缺了memory_limit_check_only这个参数，现已修复