### PR TITLE
try to fix permission

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN buildDeps='software-properties-common git libtool cmake python-dev python3-p
     mkdir build && cd build && cmake .. && make && make install && cd ../bindings/Python && python3 setup.py install && \
     apt-get purge -y --auto-remove $buildDeps && \
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
-    mkdir -p /code && useradd -r compiler && useradd -r code
+    mkdir -p /code
 
 HEALTHCHECK --interval=5s --retries=3 CMD python3 /code/service.py
 ADD server /code

--- a/server/config.py
+++ b/server/config.py
@@ -16,6 +16,9 @@ RUN_GROUP_GID = grp.getgrnam("code").gr_gid
 COMPILER_USER_UID = pwd.getpwnam("compiler").pw_uid
 COMPILER_GROUP_GID = grp.getgrnam("compiler").gr_gid
 
+SPJ_USER_UID = pwd.getpwnam("spj").pw_uid
+SPJ_GROUP_GID = grp.getgrnam("spj").gr_gid
+
 TEST_CASE_DIR = "/test_case"
 SPJ_SRC_DIR = "/judger/spj"
 SPJ_EXE_DIR = "/judger/spj"

--- a/server/entrypoint.sh
+++ b/server/entrypoint.sh
@@ -1,8 +1,19 @@
 #!/bin/bash
+useradd -u 12001 compiler
+useradd -u 12002 code
+useradd -u 12003 spj
+usermod -a -G code spj
+
 rm -rf /judger/*
 mkdir -p /judger/run /judger/spj
-chown -R compiler:compiler /judger/
-chmod -R 771 /judger/
+
+chown compiler:code /judger/run
+# 71[1] allow spj user to read user output
+chmod 711 /judger/run
+
+chown compiler:spj /judger/spj
+chmod 710 /judger/spj
+
 core=$(grep --count ^processor /proc/cpuinfo)
 n=$(($core*2))
 exec gunicorn --workers $n --threads $n --error-logfile /log/gunicorn.log --time 600 --bind 0.0.0.0:8080 server:app


### PR DESCRIPTION
修正 OJ 中的各种文件权限

 - web server 使用 `server:spj` 运行，测试用例文件夹权限是  `server:spj 710`，测试用例文件是 `server:spj 640` 。这样，spj 用户只能指定路径读取测试用例，其他的用户无法读取。
 - judge server 创建的 runtime 文件夹权限是 `compiler:code 710`
 - 提交的代码和 spj 代码文件都是 `compiler:root 400`。编译好的 用户可执行文件和 spj 可执行文件的权限是 `code:root 500` 和 `spj:root 500`
- spj 文件夹权限是 `compiler:spj 710`
- spj 代码在运行的时候，需要读取用户输出和测试用例输入，但是因为 runtime 文件夹没有权限，会修改为 `spj:root 100` 