### PR TITLE
Change port of backend to 80 in docker-compose

### DIFF
--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -18,7 +18,7 @@ services:
             # - $PWD/server:/code:ro
             - $PWD/run:/judger
         environment:
-            - BACKEND_URL=http://backend:8000/api/judge_server_heartbeat
+            - BACKEND_URL=http://backend:80/api/judge_server_heartbeat
             - SERVICE_URL=http://judge-server:12358
             - TOKEN=YOUR_TOKEN_HERE
         ports:


### PR DESCRIPTION
Extra judge servers are often run on a separate server, so the world-facing port needs to be used. `80` is the default world-facing port in `OnlineJudgeDeploy`.